### PR TITLE
Centralize status polling

### DIFF
--- a/AxisControl/SetAxisState.cs
+++ b/AxisControl/SetAxisState.cs
@@ -140,33 +140,12 @@ namespace DaleGhent.NINA.PlaneWaveTools.AxisControl {
 
         public bool Validate() {
             var i = new List<string>();
-            var status = new Dictionary<string, string>();
 
-            Task.Run(async () => {
-                try {
-                    status = await Utilities.Pwi4GetStatus(Pwi4IpAddress, Pwi4Port, CancellationToken.None);
-                } catch (HttpRequestException) {
-                    i.Add("Could not communicate with PWI4");
-                } catch (Exception ex) {
-                    i.Add($"{ex.Message}");
-                }
-            }).Wait();
-
-            if (i.Count > 0) {
-                goto end;
+            var connected = Pwi4StatusChecker.IsConnected;
+            if (!connected) {
+                i.Add(Pwi4StatusChecker.NotConnectedReason);
             }
 
-            if (!status.ContainsKey("mount.is_connected")) {
-                i.Add("Unable to determine mount connection status");
-                goto end;
-            }
-
-            if (!Utilities.Pwi4BoolStringToBoolean(status["mount.is_connected"]) && !ConnectMount) {
-                i.Add("PWI4 is not connected to the mount");
-                goto end;
-            }
-
-        end:
             if (i != Issues) {
                 Issues = i;
                 RaisePropertyChanged(nameof(Issues));

--- a/Fans/FanControlPwi4.cs
+++ b/Fans/FanControlPwi4.cs
@@ -83,33 +83,11 @@ namespace DaleGhent.NINA.PlaneWaveTools.Fans {
 
         public bool Validate() {
             var i = new List<string>();
-            var status = new Dictionary<string, string>();
 
-            Task.Run(async () => {
-                try {
-                    status = await Utilities.Pwi4GetStatus(Pwi4IpAddress, Pwi4Port, CancellationToken.None);
-                } catch (HttpRequestException) {
-                    i.Add("Could not communicate with PWI4");
-                } catch (Exception ex) {
-                    i.Add($"{ex.Message}");
-                }
-            }).Wait();
-
-            if (i.Count > 0) {
-                goto end;
+            var connected = Pwi4StatusChecker.IsConnected;
+            if (!connected) {
+                i.Add(Pwi4StatusChecker.NotConnectedReason);
             }
-
-            if (!status.ContainsKey("mount.is_connected")) {
-                i.Add("Unable to determine mount connection status");
-                goto end;
-            }
-
-            if (!Utilities.Pwi4BoolStringToBoolean(status["mount.is_connected"])) {
-                i.Add("PWI4 is not connected to the mount");
-                goto end;
-            }
-
-        end:
 
             if (i != Issues) {
                 Issues = i;

--- a/HeaterControl/HeaterControl.cs
+++ b/HeaterControl/HeaterControl.cs
@@ -119,33 +119,12 @@ namespace DaleGhent.NINA.PlaneWaveTools.HeaterControl {
 
         public bool Validate() {
             var i = new List<string>();
-            var status = new Dictionary<string, string>();
 
-            Task.Run(async () => {
-                try {
-                    status = await Utilities.Pwi4GetStatus(Pwi4IpAddress, Pwi4Port, CancellationToken.None);
-                } catch (HttpRequestException) {
-                    i.Add("Could not communicate with PWI4");
-                } catch (Exception ex) {
-                    i.Add($"{ex.Message}");
-                }
-            }).Wait();
-
-            if (i.Count > 0) {
-                goto end;
+            var connected = Pwi4StatusChecker.IsConnected;
+            if (!connected) {
+                i.Add(Pwi4StatusChecker.NotConnectedReason);
             }
 
-            if (!status.ContainsKey("mount.is_connected")) {
-                i.Add("Unable to determine mount connection status");
-                goto end;
-            }
-
-            if (!Utilities.Pwi4BoolStringToBoolean(status["mount.is_connected"])) {
-                i.Add("PWI4 is not connected to the mount");
-                goto end;
-            }
-
-        end:
             if (i != Issues) {
                 Issues = i;
                 RaisePropertyChanged(nameof(Issues));

--- a/PlaneWaveTools.cs
+++ b/PlaneWaveTools.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using CommunityToolkit.Mvvm.Input;
+using DaleGhent.NINA.PlaneWaveTools.Utility;
 using NINA.Core.Utility;
 using NINA.Plugin;
 using NINA.Plugin.Interfaces;
@@ -19,6 +20,7 @@ using System;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace DaleGhent.NINA.PlaneWaveTools {
 
@@ -189,6 +191,11 @@ namespace DaleGhent.NINA.PlaneWaveTools {
 
         protected void RaisePropertyChanged([CallerMemberName] string propertyName = null) {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public override Task Teardown() {
+            Pwi4StatusChecker.Shutdown();
+            return base.Teardown();
         }
     }
 }

--- a/Tracking/Tracking.cs
+++ b/Tracking/Tracking.cs
@@ -26,6 +26,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DaleGhent.NINA.PlaneWaveTools.Tracking {
+
     [ExportMetadata("Name", "Set Tracking")]
     [ExportMetadata("Description", "Start or stop tracking")]
     [ExportMetadata("Icon", "SpeedometerSVG")]
@@ -33,6 +34,7 @@ namespace DaleGhent.NINA.PlaneWaveTools.Tracking {
     [Export(typeof(ISequenceItem))]
     [JsonObject(MemberSerialization.OptIn)]
     public class Tracking : SequenceItem, IValidatable, INotifyPropertyChanged {
+
         [ImportingConstructor]
         public Tracking() {
             Pwi4IpAddress = Properties.Settings.Default.Pwi4IpAddress;
@@ -86,33 +88,12 @@ namespace DaleGhent.NINA.PlaneWaveTools.Tracking {
 
         public bool Validate() {
             var i = new List<string>();
-            var status = new Dictionary<string, string>();
 
-            Task.Run(async () => {
-                try {
-                    status = await Utilities.Pwi4GetStatus(Pwi4IpAddress, Pwi4Port, CancellationToken.None);
-                } catch (HttpRequestException) {
-                    i.Add("Could not communicate with PWI4");
-                } catch (Exception ex) {
-                    i.Add($"{ex.Message}");
-                }
-            }).Wait();
-
-            if (i.Count > 0) {
-                goto end;
+            var connected = Pwi4StatusChecker.IsConnected;
+            if (!connected) {
+                i.Add(Pwi4StatusChecker.NotConnectedReason);
             }
 
-            if (!status.ContainsKey("mount.is_connected")) {
-                i.Add("Unable to determine mount connection status");
-                goto end;
-            }
-
-            if (!Utilities.Pwi4BoolStringToBoolean(status["mount.is_connected"])) {
-                i.Add("PWI4 is not connected to the mount");
-                goto end;
-            }
-
-        end:
             if (i != Issues) {
                 Issues = i;
                 RaisePropertyChanged(nameof(Issues));

--- a/Utility/Pwi4StatusChecker.cs
+++ b/Utility/Pwi4StatusChecker.cs
@@ -15,7 +15,7 @@ namespace DaleGhent.NINA.PlaneWaveTools.Utility {
         private static readonly Task pollTask;
 
         static Pwi4StatusChecker() {
-            timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+            timer = new PeriodicTimer(TimeSpan.FromSeconds(5));
             pollCts = new CancellationTokenSource();
             pollTask = Task.Run(() => Poll(pollCts.Token));
         }

--- a/Utility/Pwi4StatusChecker.cs
+++ b/Utility/Pwi4StatusChecker.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DaleGhent.NINA.PlaneWaveTools.Utility {
+
+    internal static class Pwi4StatusChecker {
+        private static readonly PeriodicTimer timer;
+        private static readonly CancellationTokenSource pollCts;
+        private static readonly Task pollTask;
+
+        static Pwi4StatusChecker() {
+            timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+            pollCts = new CancellationTokenSource();
+            pollTask = Task.Run(() => Poll(pollCts.Token));
+        }
+
+        public static bool IsConnected { get; private set; }
+        public static string NotConnectedReason { get; private set; }
+        public static bool M3PortExists { get; private set; }
+
+        private static async Task Poll(CancellationToken token) {
+            while (await timer.WaitForNextTickAsync() && !token.IsCancellationRequested) {
+                try {
+                    var status = await Utilities.Pwi4GetStatus(Properties.Settings.Default.Pwi4IpAddress, Properties.Settings.Default.Pwi4Port, token);
+
+                    if (status.ContainsKey("mount.is_connected")) {
+                        if (Utilities.Pwi4BoolStringToBoolean(status["mount.is_connected"])) {
+                            IsConnected = true;
+                            NotConnectedReason = "";
+                        } else {
+                            IsConnected = false;
+                            NotConnectedReason = "PWI4 is not connected to the mount";
+                        }
+                    } else {
+                        NotConnectedReason = "Unable to determine mount connection status";
+                    }
+
+                    if (status.ContainsKey("m3.exists")) {
+                        M3PortExists = short.Parse(status["m3.exists"], CultureInfo.InvariantCulture) != 0;
+                    } else {
+                        M3PortExists = false;
+                    }
+                } catch (HttpRequestException) {
+                    NotConnectedReason = "Could not communicate with PWI4";
+                    IsConnected = false;
+                    M3PortExists = false;
+                } catch (Exception ex) {
+                    NotConnectedReason = ex.Message;
+                    IsConnected = false;
+                    M3PortExists = false;
+                }
+            }
+        }
+
+        public static void Shutdown() {
+            try {
+                pollCts?.Cancel();
+            } catch { }
+        }
+    }
+}

--- a/Utility/Pwi4StatusChecker.cs
+++ b/Utility/Pwi4StatusChecker.cs
@@ -15,7 +15,7 @@ namespace DaleGhent.NINA.PlaneWaveTools.Utility {
         private static readonly Task pollTask;
 
         static Pwi4StatusChecker() {
-            timer = new PeriodicTimer(TimeSpan.FromSeconds(5));
+            timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
             pollCts = new CancellationTokenSource();
             pollTask = Task.Run(() => Poll(pollCts.Token));
         }


### PR DESCRIPTION
Introduce a static class that polls PWI4 on a 1 second interval and exposes info if PWI4 is connected.

Following advantages:
- Centralized logic to process connection state for instruction validation logic (deduplicate code)
- Avoid polling PWI4 many times in parallel when multiple instructions are validated
- Avoid .Wait() in synchronous code blocks
- Polling is done in the background. Validation logic will be much faster